### PR TITLE
Updated to allow deletions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Rclone encrypts and uploads from a local folder (`local_decrypt_dir`) to the clo
 
 Rclone creates a config file: `config.json`. This is used to get access to the cloud provider and encryption/decryption keys. This can either be set up via Rclone or by using the templates located in the [rclone directory](rclone/) (just copy the file and name it `rclone.conf`).
 
-Some have reported permission issues with Rclone directory. If that occurs it can be fixed by setting `--uid` in `rclone_mount_options` in [config.json](config.json).
+Some have reported permission issues with Rclone directory. If that occurs it can be fixed by setting uid/gid variables under the # Mount user Id section in [config](config).
 
 ## UnionFS
 UnionFS is used to mount both cloud and local media to a local folder (`local_media_dir`).

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ This gives us a total of 5 directories:
 Cloud data is mounted to a local folder (`cloud_encrypt_dir`). This folder is then decrypted and mounted to a local folder (`cloud_decrypt_dir`).
 
 A local folder (`local_decrypt_dir`) is created to contain media stored locally.
-The local folder (`local_decrypt_dir`) and cloud folder (`cloud_decrypt_dir`) are then mounted to a third folder (`local_media_dir`) with certain permissions - local folder with Read/Write permissions and cloud folder with Read-only permissions.
+The local folder (`local_decrypt_dir`) and cloud folder (`cloud_decrypt_dir`) are then mounted to a third folder (`local_media_dir`) with certain permissions - local folder with Read/Write permissions. cloud folder cby default is set to Read-only permissions. If you wish to have the capablity to delete files, please change delete_flag to Y in config.
 
-Everytime new media is retrieved it should be added to `local_media_dir` or `local_decrypt_dir`. By adding new data to `local_media_dir` it will automatically write it to `local_decrypt_dir` because of the permissions stated earlier. At this moment the media has not been uploaded to the cloud yet but only appears locally.
+Everytime new media is retrieved it should be added to `local_media_dir` or `local_decrypt_dir`. By adding new data to `local_media_dir` it will automatically write it to `local_decrypt_dir` because of the permissions and the UnionFS priority setup. At this moment the media has not been uploaded to the cloud yet but only appears locally.
 
 When running cloudupload it makes sure to upload the files from `local_decrypt_dir` to the cloud. This will only upload to the cloud and the file appears both locally and on the cloud. However, in `local_media_dir` it only appears as one file.
 
@@ -88,7 +88,7 @@ Some have reported permission issues with Rclone directory. If that occurs it ca
 ## UnionFS
 UnionFS is used to mount both cloud and local media to a local folder (`local_media_dir`).
 
- - Cloud media is mounted with Read-only permissions.
+ - Cloud media is mounted with Read-only permissions by default, or Read/Write /w the delete_flag set to "Y". This will only allow deletion and not uploads.
  - Local media is mounted with Read/Write permissions.
 
 The reason for these permissions are that when writing to the local folder (`local_media_dir`) it will not try to write it directly to the cloud folder, but instead to the local media (`local_decrypt_dir`). Later this will be encrypted and uploaded to the cloud by Rclone.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This gives us a total of 5 directories:
 Cloud data is mounted to a local folder (`cloud_encrypt_dir`). This folder is then decrypted and mounted to a local folder (`cloud_decrypt_dir`).
 
 A local folder (`local_decrypt_dir`) is created to contain media stored locally.
-The local folder (`local_decrypt_dir`) and cloud folder (`cloud_decrypt_dir`) are then mounted to a third folder (`local_media_dir`) with certain permissions - local folder with Read/Write permissions. cloud folder cby default is set to Read-only permissions. If you wish to have the capablity to delete files, please change delete_flag to Y in config.
+The local folder (`local_decrypt_dir`) and cloud folder (`cloud_decrypt_dir`) are then mounted to a third folder (`local_media_dir`) with certain permissions - local folder with Read/Write permissions. The cloud folder by default is set to Read-only permissions. If you wish to have the capablity to delete files, please change delete_flag to Y in config.
 
 Everytime new media is retrieved it should be added to `local_media_dir` or `local_decrypt_dir`. By adding new data to `local_media_dir` it will automatically write it to `local_decrypt_dir` because of the permissions and the UnionFS priority setup. At this moment the media has not been uploaded to the cloud yet but only appears locally.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This gives us a total of 5 directories:
 Cloud data is mounted to a local folder (`cloud_encrypt_dir`). This folder is then decrypted and mounted to a local folder (`cloud_decrypt_dir`).
 
 A local folder (`local_decrypt_dir`) is created to contain media stored locally.
-The local folder (`local_decrypt_dir`) and cloud folder (`cloud_decrypt_dir`) are then mounted to a third folder (`local_media_dir`) with certain permissions - local folder with Read/Write permissions at top branch and cloud folder with Read/Write but as 2nd branch so writes will go to local folder, but will still allow deletions from the cloud folder via ufs.
+The local folder (`local_decrypt_dir`) and cloud folder (`cloud_decrypt_dir`) are then mounted to a third folder (`local_media_dir`) with certain permissions - local folder with Read/Write permissions and cloud folder with Read-only permissions.
 
 Everytime new media is retrieved it should be added to `local_media_dir` or `local_decrypt_dir`. By adding new data to `local_media_dir` it will automatically write it to `local_decrypt_dir` because of the permissions stated earlier. At this moment the media has not been uploaded to the cloud yet but only appears locally.
 
@@ -88,10 +88,10 @@ Some have reported permission issues with Rclone directory. If that occurs it ca
 ## UnionFS
 UnionFS is used to mount both cloud and local media to a local folder (`local_media_dir`).
 
- - Local media is mounted with Read/Write permissions at top branch position.
- - Cloud media is mounted with Read/Write permissions at lower branch position so all writes go to Local, but deletions are still allowed.
- 
-The reason for these permissions are that when writing to the local folder (`local_media_dir`) it will not try to write it directly to the cloud folder, but instead to the local media (`local_decrypt_dir`). This is acheived through the priority system in UnionFS and the writes defaulting top branch 1st.  Later this will be encrypted and uploaded to the cloud by Rclone.
+ - Cloud media is mounted with Read-only permissions.
+ - Local media is mounted with Read/Write permissions.
+
+The reason for these permissions are that when writing to the local folder (`local_media_dir`) it will not try to write it directly to the cloud folder, but instead to the local media (`local_decrypt_dir`). Later this will be encrypted and uploaded to the cloud by Rclone.
 
 ## Setup
 # Installation without easy install

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This gives us a total of 5 directories:
 Cloud data is mounted to a local folder (`cloud_encrypt_dir`). This folder is then decrypted and mounted to a local folder (`cloud_decrypt_dir`).
 
 A local folder (`local_decrypt_dir`) is created to contain media stored locally.
-The local folder (`local_decrypt_dir`) and cloud folder (`cloud_decrypt_dir`) are then mounted to a third folder (`local_media_dir`) with certain permissions - local folder with Read/Write permissions. The cloud folder by default is set to Read-only permissions. If you wish to have the capablity to delete files, please change delete_flag to Y in config.
+The local folder (`local_decrypt_dir`) and cloud folder (`cloud_decrypt_dir`) are then mounted to a third folder (`local_media_dir`) with certain permissions - local folder with Read/Write permissions. The cloud folder by default is set to Read-only permissions. If you wish to have the capablity to delete files, please change delete_flag to Y in config. This will allow you to delete items in plex and it will remove them from the cloud also.
 
 Everytime new media is retrieved it should be added to `local_media_dir` or `local_decrypt_dir`. By adding new data to `local_media_dir` it will automatically write it to `local_decrypt_dir` because of the permissions and the UnionFS priority setup. At this moment the media has not been uploaded to the cloud yet but only appears locally.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This gives us a total of 5 directories:
 Cloud data is mounted to a local folder (`cloud_encrypt_dir`). This folder is then decrypted and mounted to a local folder (`cloud_decrypt_dir`).
 
 A local folder (`local_decrypt_dir`) is created to contain media stored locally.
-The local folder (`local_decrypt_dir`) and cloud folder (`cloud_decrypt_dir`) are then mounted to a third folder (`local_media_dir`) with certain permissions - local folder with Read/Write permissions and cloud folder with Read-only permissions.
+The local folder (`local_decrypt_dir`) and cloud folder (`cloud_decrypt_dir`) are then mounted to a third folder (`local_media_dir`) with certain permissions - local folder with Read/Write permissions at top branch and cloud folder with Read/Write but as 2nd branch so writes will go to local folder, but will still allow deletions from the cloud folder via ufs.
 
 Everytime new media is retrieved it should be added to `local_media_dir` or `local_decrypt_dir`. By adding new data to `local_media_dir` it will automatically write it to `local_decrypt_dir` because of the permissions stated earlier. At this moment the media has not been uploaded to the cloud yet but only appears locally.
 
@@ -88,10 +88,10 @@ Some have reported permission issues with Rclone directory. If that occurs it ca
 ## UnionFS
 UnionFS is used to mount both cloud and local media to a local folder (`local_media_dir`).
 
- - Cloud media is mounted with Read-only permissions.
- - Local media is mounted with Read/Write permissions.
-
-The reason for these permissions are that when writing to the local folder (`local_media_dir`) it will not try to write it directly to the cloud folder, but instead to the local media (`local_decrypt_dir`). Later this will be encrypted and uploaded to the cloud by Rclone.
+ - Local media is mounted with Read/Write permissions at top branch position.
+ - Cloud media is mounted with Read/Write permissions at lower branch position so all writes go to Local, but deletions are still allowed.
+ 
+The reason for these permissions are that when writing to the local folder (`local_media_dir`) it will not try to write it directly to the cloud folder, but instead to the local media (`local_decrypt_dir`). This is acheived through the priority system in UnionFS and the writes defaulting top branch 1st.  Later this will be encrypted and uploaded to the cloud by Rclone.
 
 ## Setup
 # Installation without easy install

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This gives us a total of 5 directories:
 Cloud data is mounted to a local folder (`cloud_encrypt_dir`). This folder is then decrypted and mounted to a local folder (`cloud_decrypt_dir`).
 
 A local folder (`local_decrypt_dir`) is created to contain media stored locally.
-The local folder (`local_decrypt_dir`) and cloud folder (`cloud_decrypt_dir`) are then mounted to a third folder (`local_media_dir`) with certain permissions - local folder with Read/Write permissions. The cloud folder by default is set to Read-only permissions. If you wish to have the capablity to delete files, please change delete_flag to Y in config. This will allow you to delete items in plex and it will remove them from the cloud also.
+The local folder (`local_decrypt_dir`) and cloud folder (`cloud_decrypt_dir`) are then mounted to a third folder (`local_media_dir`) with certain permissions - local folder with Read/Write permissions. The cloud folder by default is set to Read-only permissions. If you wish to have the capablity to delete files, please change delete_flag to 1 in config. This will allow you to delete items in plex and it will remove them from the cloud also.
 
 Everytime new media is retrieved it should be added to `local_media_dir` or `local_decrypt_dir`. By adding new data to `local_media_dir` it will automatically write it to `local_decrypt_dir` because of the permissions and the UnionFS priority setup. At this moment the media has not been uploaded to the cloud yet but only appears locally.
 
@@ -88,7 +88,7 @@ Some have reported permission issues with Rclone directory. If that occurs it ca
 ## UnionFS
 UnionFS is used to mount both cloud and local media to a local folder (`local_media_dir`).
 
- - Cloud media is mounted with Read-only permissions by default, or Read/Write /w the delete_flag set to "Y". This will only allow deletion and not uploads.
+ - Cloud media is mounted with Read-only permissions by default, or Read/Write /w the delete_flag set to 1. This will only allow deletion and not uploads.
  - Local media is mounted with Read/Write permissions.
 
 The reason for these permissions are that when writing to the local folder (`local_media_dir`) it will not try to write it directly to the cloud folder, but instead to the local media (`local_decrypt_dir`). Later this will be encrypted and uploaded to the cloud by Rclone.

--- a/config
+++ b/config
@@ -31,7 +31,7 @@ uid=$(id -u)
 gid=$(id -g)
 
 # Delete flag used to enable deletions from local media dir by enabling RW. Will not write, but will allow delete.
-delete_flag="N" #Set to Y if you want to allow
+delete_flag=0 #Set to 1 if you want to allow
 
 ufs_options="-o cow,allow_other,direct_io,nonempty,auto_cache,sync_read,uid=$uid,gid=$gid"
 
@@ -46,7 +46,7 @@ mongo_host="localhost"
 mongo_user=""
 mongo_password=""
 
-if [ $delete_flag="Y" ]; then
+if [ $delete_flag=1 ]; then
     plexdrive_options="--temp=${plexdrive_temp_dir} -o allow_other --clear-chunk-max-size=300G --clear-chunk-age=24h --chunk-size=10M"
 else
     plexdrive_options="--temp=${plexdrive_temp_dir} -o allow_other,read_only --clear-chunk-max-size=300G --clear-chunk-age=24h --chunk-size=10M"
@@ -61,7 +61,7 @@ rclone_bin="${rclone_dir}/rclone"
 rclone_config="${rclone_dir}/rclone.conf"
 rclone_options="--buffer-size 500M --checkers 16"
 
-if [ $delete_flag="Y" ]; then
+if [ $delete_flag=1 ]; then
     rclone_mount_options="${rclone_options} --allow-non-empty --allow-other --max-read-ahead 30G"
 else
     rclone_mount_options="${rclone_options} --read-only --allow-non-empty --allow-other --max-read-ahead 30G"

--- a/config
+++ b/config
@@ -46,7 +46,7 @@ mongo_host="localhost"
 mongo_user=""
 mongo_password=""
 
-if [ $delete_flag=1 ]; then
+if [ "$delete_flag" == "1" ]; then
     plexdrive_options="--temp=${plexdrive_temp_dir} -o allow_other --clear-chunk-max-size=300G --clear-chunk-age=24h --chunk-size=10M"
 else
     plexdrive_options="--temp=${plexdrive_temp_dir} -o allow_other,read_only --clear-chunk-max-size=300G --clear-chunk-age=24h --chunk-size=10M"
@@ -61,7 +61,7 @@ rclone_bin="${rclone_dir}/rclone"
 rclone_config="${rclone_dir}/rclone.conf"
 rclone_options="--buffer-size 500M --checkers 16"
 
-if [ $delete_flag=1 ]; then
+if [ "$delete_flag" == "1" ]; then
     rclone_mount_options="${rclone_options} --allow-non-empty --allow-other --max-read-ahead 30G"
 else
     rclone_mount_options="${rclone_options} --read-only --allow-non-empty --allow-other --max-read-ahead 30G"

--- a/config
+++ b/config
@@ -44,7 +44,7 @@ mongo_host="localhost"
 mongo_user=""
 mongo_password=""
 
-plexdrive_options="--temp=${plexdrive_temp_dir} -o allow_other,read_only --clear-chunk-max-size=300G --clear-chunk-age=24h --chunk-size=10M"
+plexdrive_options="--temp=${plexdrive_temp_dir} -o allow_other --clear-chunk-max-size=300G --clear-chunk-age=24h --chunk-size=10M"
 
 
 ###############################################################################
@@ -55,7 +55,7 @@ rclone_bin="${rclone_dir}/rclone"
 
 rclone_config="${rclone_dir}/rclone.conf"
 rclone_options="--buffer-size 500M --checkers 16"
-rclone_mount_options="${rclone_options} --read-only --allow-non-empty --allow-other --max-read-ahead 30G"
+rclone_mount_options="${rclone_options} --allow-non-empty --allow-other --max-read-ahead 30G"
 
 # Rclone endpoints
 rclone_cloud_endpoint="gd-crypt:"

--- a/config
+++ b/config
@@ -30,8 +30,10 @@ ufs_bin="/usr/bin/unionfs"
 uid=$(id -u)
 gid=$(id -g)
 
-ufs_options="-o cow,allow_other,direct_io,nonempty,auto_cache,sync_read,uid=$uid,gid=$gid"
+# Delete flag used to enable deletions from local media dir by enabling RW. Will not write, but will allow delete.
+delete_flag="N" #Set to Y if you want to allow
 
+ufs_options="-o cow,allow_other,direct_io,nonempty,auto_cache,sync_read,uid=$uid,gid=$gid"
 
 ###############################################################################
 # PLEXDRIVE
@@ -44,8 +46,11 @@ mongo_host="localhost"
 mongo_user=""
 mongo_password=""
 
-plexdrive_options="--temp=${plexdrive_temp_dir} -o allow_other --clear-chunk-max-size=300G --clear-chunk-age=24h --chunk-size=10M"
-
+if [ $delete_flag="Y" ]; then
+    plexdrive_options="--temp=${plexdrive_temp_dir} -o allow_other --clear-chunk-max-size=300G --clear-chunk-age=24h --chunk-size=10M"
+else
+    plexdrive_options="--temp=${plexdrive_temp_dir} -o allow_other,read_only --clear-chunk-max-size=300G --clear-chunk-age=24h --chunk-size=10M"
+fi
 
 ###############################################################################
 # RCLONE
@@ -55,7 +60,13 @@ rclone_bin="${rclone_dir}/rclone"
 
 rclone_config="${rclone_dir}/rclone.conf"
 rclone_options="--buffer-size 500M --checkers 16"
-rclone_mount_options="${rclone_options} --allow-non-empty --allow-other --max-read-ahead 30G"
+
+if [ $delete_flag="Y" ]; then
+    rclone_mount_options="${rclone_options} --allow-non-empty --allow-other --max-read-ahead 30G"
+else
+    rclone_mount_options="${rclone_options} --read-only --allow-non-empty --allow-other --max-read-ahead 30G"
+fi
+
 
 # Rclone endpoints
 rclone_cloud_endpoint="gd-crypt:"

--- a/scripts/mount.remote
+++ b/scripts/mount.remote
@@ -111,7 +111,7 @@ mount_union () {
 			count=$(($count - 1))
 		done
 		
-		if [ $delete_flag="Y" ]; then
+		if [ $delete_flag=1 ]; then
 			ufs_mounts="${local_decrypt_dir}=RW:${cloud_decrypt_dir}=RW"
 		else
 			ufs_mounts="${local_decrypt_dir}=RW:${cloud_decrypt_dir}=RO"

--- a/scripts/mount.remote
+++ b/scripts/mount.remote
@@ -111,7 +111,7 @@ mount_union () {
 			count=$(($count - 1))
 		done
 		
-		if [ $delete_flag=1 ]; then
+		if [ "$delete_flag" -eq "0" ]; then
 			ufs_mounts="${local_decrypt_dir}=RW:${cloud_decrypt_dir}=RW"
 		else
 			ufs_mounts="${local_decrypt_dir}=RW:${cloud_decrypt_dir}=RO"

--- a/scripts/mount.remote
+++ b/scripts/mount.remote
@@ -111,7 +111,7 @@ mount_union () {
 			count=$(($count - 1))
 		done
 		
-		if [ "$delete_flag" -eq "0" ]; then
+		if [ "$delete_flag" == "1" ]; then
 			ufs_mounts="${local_decrypt_dir}=RW:${cloud_decrypt_dir}=RW"
 		else
 			ufs_mounts="${local_decrypt_dir}=RW:${cloud_decrypt_dir}=RO"

--- a/scripts/mount.remote
+++ b/scripts/mount.remote
@@ -111,7 +111,7 @@ mount_union () {
 			count=$(($count - 1))
 		done
 
-		ufs_mounts="${local_decrypt_dir}=RW:${cloud_decrypt_dir}=RO"
+		ufs_mounts="${local_decrypt_dir}=RW:${cloud_decrypt_dir}=RW"
 
 		echo "[ $(date ${date_format}) ] Mounting final library with UnionFS in mountpoint: ${local_media_dir}"
 		"${ufs_bin}" $ufs_options "${ufs_mounts}" "${local_media_dir}"

--- a/scripts/mount.remote
+++ b/scripts/mount.remote
@@ -110,8 +110,12 @@ mount_union () {
 			sleep 10
 			count=$(($count - 1))
 		done
-
-		ufs_mounts="${local_decrypt_dir}=RW:${cloud_decrypt_dir}=RW"
+		
+		if [ $delete_flag="Y" ]; then
+			ufs_mounts="${local_decrypt_dir}=RW:${cloud_decrypt_dir}=RW"
+		else
+			ufs_mounts="${local_decrypt_dir}=RW:${cloud_decrypt_dir}=RO"
+		fi
 
 		echo "[ $(date ${date_format}) ] Mounting final library with UnionFS in mountpoint: ${local_media_dir}"
 		"${ufs_bin}" $ufs_options "${ufs_mounts}" "${local_media_dir}"


### PR DESCRIPTION
Updated config/mount script to allow RW which will only allow deletions. UnionFS still will write to local_decrypt due to the order of locations in script. Tested and worked OK.

See https://github.com/madslundt/cloud-media-scripts/issues/36 for screen shots of proof for deletions.