### PR TITLE
Added path for mountcheck

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -49,6 +49,7 @@ sed -i "s|INSERT_CONFIG_FILE|${mypwd}/config|g" "${mypwd}/scripts/"*
 sed -i "s|INSERT_CONFIG_FILE|${mypwd}/config|g" "${mypwd}/setup.sh"
 sed -i "s|bash mount.remote|bash ${mypwd}/scripts/mount.remote|g" "${mypwd}/scripts/"*
 sed -i "s|bash umount.remote|bash ${mypwd}/scripts/umount.remote|g" "${mypwd}/scripts/"*
+sed -i "s|bash mountcheck|bash ${mypwd}/scripts/mountcheck|g" "${mypwd}/scripts/"*
 sed -i "s|logs/|${mypwd}/logs/|g" "${mypwd}/cron"
 sed -i "s|scripts/|${mypwd}/scripts/|g" "${mypwd}/cron"
 


### PR DESCRIPTION
Added path for mountcheck script in the installation file.

The empty.trash file uses this check, without the path an error occurs when checking the mount points.