### PR TITLE
Cloudupload Update

### DIFF
--- a/scripts/cloudupload
+++ b/scripts/cloudupload
@@ -8,24 +8,24 @@
 ###################################
 
 ##############################################################################
-
 # Set Move/Copy based on move_ind
 if [ "${move_ind}" = "1" ]; then
-	copy_cmd="move"
+        copy_cmd="move"
 else
-	copy_cmd="copy"
-fi	
+        copy_cmd="copy"
+fi
 
 # If script is already running; abort.
 if pidof -o %PPID -x "$(basename "$0")"; then
-	echo "[ $(date ${date_format}) ] Upload already in progress. Aborting."
-	exit 3
+        echo "[ $(date ${date_format}) ] Upload already in progress. Aborting."
+        exit 3
 fi
 
 echo "[ $(date ${date_format}) ] ###### Start cloud upload ######"
-
 oldSize=0
 addedSize=0
+fileSize=0
+cloud_up_limit=$((${upload_limit}*1073741824))
 
 # Check if any files exist, if not exit
 file_ct=$(find "${local_decrypt_dir}" -type f | wc -l)
@@ -36,61 +36,51 @@ if [ "$file_ct" = 0 ];then
 fi
 
 # Generate filelist and iterate through it...
-find "${local_decrypt_dir}" -type f -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d: -f2- | awk '{$1=$2=$3=""; print $0}' |
-	while read -r n; do
 
-		# Find the pathname relative to the root of your remote and store filename
-		filename="$(echo "$n" | sed -e s@"${local_decrypt_dir}"@@)"
-		destpath="$(dirname "$n" | sed -e s@"${local_decrypt_dir}"@@)"
+find "${local_decrypt_dir}" -type f -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d: -f2- | awk '{$1=$2=$                                                                   3=""; print $0}' |
+(
+        while read -r n; do
+                # Find the pathname relative to the root of your remote and store filename
+                filename="$(echo "$n" | sed -e s@"${local_decrypt_dir}"@@)"
+                destpath="$(dirname "$n" | sed -e s@"${local_decrypt_dir}"@@)"
+                basefile="$(basename "$n")"
 
-		# Skip hidden or partial files.
-		case "$n" in
-			(*.partial~) continue ;;
-			(*_HIDDEN~) continue ;;
-			(*.QTFS) continue ;;
-			(*.fuse*) continue ;;
-			(*.inProgress*) continue ;;
-			(.DS_STORE) continue ;;
-		esac
+                # Skip hidden or partial files.
+                case "$n" in
+                        (*.partial~) continue ;;
+                        (*_HIDDEN~) continue ;;
+                        (*.QTFS) continue ;;
+                        (*.fuse*) continue ;;
+                        (*.inProgress*) continue ;;
+                        (.DS_STORE) continue ;;
+                esac
 
-		if [ -f "${cloud_decrypt_dir}${filename}" ]; then
+                if [ -f "${cloud_decrypt_dir}${filename}" ]; then
             continue
         fi
+                # If file is opened by another process, wait until it isn't.
+                while [ "$(lsof "$n" >/dev/null 2>&1)" ] || \
+                        [ "$(lsof "${local_decrypt_dir}/${n}" >/dev/null 2>&1)" ] || \
+                        [ "$(lsof "${local_media_dir}/${n}" >/dev/null 2>&1)" ]; do
+                        echo "[ $(date ${date_format}) ] File -> ${n} in use. Retrying in 10 seconds."
+                        sleep 10
+                done
 
-		# If file is opened by another process, wait until it isn't.
-		while [ "$(lsof "$n" >/dev/null 2>&1)" ] || \
-			[ "$(lsof "${local_decrypt_dir}/${n}" >/dev/null 2>&1)" ] || \
-			[ "$(lsof "${local_media_dir}/${n}" >/dev/null 2>&1)" ]; do
-			echo "[ $(date ${date_format}) ] File -> ${n} in use. Retrying in 10 seconds."
-			sleep 10
-		done
+                fileSize=$(stat "$n" -c %s)
+                addedSize=$(($addedSize+$fileSize))
 
-		fileSize=$(du -sb "$n" | awk '{print $1}')
-		addedSize=$((addedSize + fileSize))
-		sizeInMb=$((addedSize / 1000 / 1000))
-
-		if [[ "${upload_limit}" -gt "0" ]]; then
-			if [[ "$((sizeInMb / 1000))" -gt "${upload_limit}" ]]; then
-				echo "[ $(date ${date_format}) ] Aborted upload to not exceed ${upload_limit}GB."
-				echo "[ $(date ${date_format}) ] $((oldSize / 1000 / 1000 / 1000))GB uploaded"
+                if [[ "$cloud_up_limit" -gt "0" ]]; then
+                        if [[ "$addedSize" -gt "$cloud_up_limit" ]]; then
+                                echo "[ $(date ${date_format}) ] Aborted upload to not exceed $(numfmt --to=iec $cloud_up_                                                                   limit --suffix=B --format=""%.2f"")."
+                                echo "[ $(date ${date_format}) ] $(numfmt --to=iec $oldSize --suffix=B --format=""%.2f"")                                                                    uploaded"
                 break
-			fi
-		fi
-
-		# Copy/Move file to remote destination[s], retaining path
-		"${rclone_bin}" "${copy_cmd}" --config="${rclone_config}" $rclone_options "$n" "${rclone_cloud_endpoint}${destpath}" >/dev/null 2>&1
-
-
-        diffSize=$((addedSize - oldSize))
-        if [[ "${sizeInMb}" -gt 1000 ]]; then
-                if [[ "${diffSize}" -gt "1000000000" ]]; then # greater than 1 GB
-                        oldSize=$addedSize
-                        echo "[ $(date ${date_format}) ] $((sizeInMb / 1000)) GB uploaded"
+                        fi
                 fi
-        elif [[ "${diffSize}" -gt "100000000" ]]; then # greater than 100 MB
-                oldSize=$addedSize
-                echo "[ $(date ${date_format}) ] ${sizeInMb} MB uploaded"
-        fi
-	done
-
+                # Copy/Move file to remote destination[s], retaining path
+                "${rclone_bin}" "${copy_cmd}" --config="${rclone_config}" $rclone_options "$n" "${rclone_cloud_endpoint}${                                                                   destpath}"
+                echo "[ $(date ${date_format}) ] Uploaded $(numfmt --to=iec $fileSize --suffix=B --format="%.2f") - $basef                                                                   ile"
+        diffSize=$((addedSize-oldSize))
+        done
+echo "[ $(date ${date_format}) ] Total of $(numfmt --to=iec $addedSize --suffix=B --format="%.2f") uploaded."
 echo "[ $(date ${date_format}) ] ###### Cloud upload ended successfully ######"
+)

--- a/scripts/cloudupload
+++ b/scripts/cloudupload
@@ -37,7 +37,7 @@ fi
 
 # Generate filelist and iterate through it...
 
-find "${local_decrypt_dir}" -type f -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d: -f2- | awk '{$1=$2=$                                                                   3=""; print $0}' |
+find "${local_decrypt_dir}" -type f -print0 | xargs -0 stat --format '%Y :%y %n' | sort -nr | cut -d: -f2- | awk '{$1=$2=$3=""; print $0}' |
 (
         while read -r n; do
                 # Find the pathname relative to the root of your remote and store filename
@@ -71,14 +71,14 @@ find "${local_decrypt_dir}" -type f -print0 | xargs -0 stat --format '%Y :%y %n'
 
                 if [[ "$cloud_up_limit" -gt "0" ]]; then
                         if [[ "$addedSize" -gt "$cloud_up_limit" ]]; then
-                                echo "[ $(date ${date_format}) ] Aborted upload to not exceed $(numfmt --to=iec $cloud_up_                                                                   limit --suffix=B --format=""%.2f"")."
-                                echo "[ $(date ${date_format}) ] $(numfmt --to=iec $oldSize --suffix=B --format=""%.2f"")                                                                    uploaded"
+                                echo "[ $(date ${date_format}) ] Aborted upload to not exceed $(numfmt --to=iec $cloud_up_limit --suffix=B --format=""%.2f"")."
+                                echo "[ $(date ${date_format}) ] $(numfmt --to=iec $oldSize --suffix=B --format=""%.2f"") uploaded"
                 break
                         fi
                 fi
                 # Copy/Move file to remote destination[s], retaining path
-                "${rclone_bin}" "${copy_cmd}" --config="${rclone_config}" $rclone_options "$n" "${rclone_cloud_endpoint}${                                                                   destpath}"
-                echo "[ $(date ${date_format}) ] Uploaded $(numfmt --to=iec $fileSize --suffix=B --format="%.2f") - $basef                                                                   ile"
+                "${rclone_bin}" "${copy_cmd}" --config="${rclone_config}" $rclone_options "$n" "${rclone_cloud_endpoint}${destpath}"
+                echo "[ $(date ${date_format}) ] Uploaded $(numfmt --to=iec $fileSize --suffix=B --format="%.2f") - $basefile"
         diffSize=$((addedSize-oldSize))
         done
 echo "[ $(date ${date_format}) ] Total of $(numfmt --to=iec $addedSize --suffix=B --format="%.2f") uploaded."


### PR DESCRIPTION
Added more descriptive log info saying which files are uploaded, the size and the total amount uploaded. Remove the prior <> 1000MB if as not needed and can use numfmt.

```
dulanic@mediaserver:/opt/cloud-media-scripts/scripts$ ./cloudupload
[ 2018-04-17@21:21:55 ] ###### Start cloud upload ######
[ 2018-04-17@21:25:32 ] Uploaded 4.00GB - **REDACTED**.mkv
[ 2018-04-17@21:25:32 ] Total of 4.00GB uploaded.
[ 2018-04-17@21:25:32 ] ###### Cloud upload ended successfully ######

```
